### PR TITLE
Fix: Implement FORMEL tax calculation for BL and BE cantons

### DIFF
--- a/lib/taxes/tarif/index.ts
+++ b/lib/taxes/tarif/index.ts
@@ -78,7 +78,7 @@ export const calculateTaxesAmount = (amount: Dinero<number>, tarif: TaxTarif) =>
       taxes = calculateTaxesByTypeFreiburg(amount, tarif);
       break;
     case 'FORMEL':
-      taxes = dineroChf(0); // TODO implement
+      taxes = calculateTaxesByTypeFormel(amount, tarif);
       break;
     default:
       throw new Error(`Unknown table type ${tarif.tableType}`);
@@ -172,6 +172,139 @@ const calculateTaxesByTypeBund = (amount: Dinero<number>, tarif: TaxTarif) => {
 
 const calculateTaxesByTypeFlattax = (amount: Dinero<number>, tarif: TaxTarif) => {
   return multiplyDineroPercent(amount, tarif.table[0].percent, 5);
+};
+
+const evaluateFormula = (formula: string, wert: number): number => {
+  if (!formula || formula.trim() === '') return 0;
+
+  const tokens = tokenizeFormula(formula, wert);
+  const ctx = { pos: 0 };
+  const result = parseExpression(tokens, ctx);
+  if (ctx.pos !== tokens.length) {
+    throw new Error(`Unexpected token '${tokens[ctx.pos]}' in formula: ${formula}`);
+  }
+  return result;
+};
+
+const tokenizeFormula = (formula: string, wert: number): string[] => {
+  const tokens: string[] = [];
+  let i = 0;
+  const s = formula;
+
+  while (i < s.length) {
+    if (s[i] === ' ' || s[i] === '\t') {
+      i++;
+    } else if (s[i] === '$') {
+      // $wert$ variable
+      const end = s.indexOf('$', i + 1);
+      if (end === -1) throw new Error(`Unterminated variable in formula: ${formula}`);
+      const variableName = s.substring(i + 1, end);
+      if (variableName !== 'wert') {
+        throw new Error(`Unknown variable '${variableName}' in formula: ${formula}`);
+      }
+      tokens.push(String(wert));
+      i = end + 1;
+    } else if (s.substring(i, i + 3) === 'log') {
+      tokens.push('log');
+      i += 3;
+    } else if ('+-*/()'.includes(s[i])) {
+      tokens.push(s[i]);
+      i++;
+    } else if (/[\d.]/.test(s[i])) {
+      let num = '';
+      while (i < s.length && /[\d.]/.test(s[i])) {
+        num += s[i];
+        i++;
+      }
+      tokens.push(num);
+    } else {
+      throw new Error(`Unexpected character '${s[i]}' in formula: ${formula}`);
+    }
+  }
+  return tokens;
+};
+
+const parseExpression = (tokens: string[], ctx: { pos: number }): number => {
+  let left = parseTerm(tokens, ctx);
+  while (ctx.pos < tokens.length && (tokens[ctx.pos] === '+' || tokens[ctx.pos] === '-')) {
+    const op = tokens[ctx.pos++];
+    const right = parseTerm(tokens, ctx);
+    left = op === '+' ? left + right : left - right;
+  }
+  return left;
+};
+
+const parseTerm = (tokens: string[], ctx: { pos: number }): number => {
+  let left = parseUnary(tokens, ctx);
+  while (ctx.pos < tokens.length && (tokens[ctx.pos] === '*' || tokens[ctx.pos] === '/')) {
+    const op = tokens[ctx.pos++];
+    const right = parseUnary(tokens, ctx);
+    left = op === '*' ? left * right : left / right;
+  }
+  return left;
+};
+
+const parseUnary = (tokens: string[], ctx: { pos: number }): number => {
+  if (tokens[ctx.pos] === '-') {
+    ctx.pos++;
+    return -parsePrimary(tokens, ctx);
+  }
+  return parsePrimary(tokens, ctx);
+};
+
+const parsePrimary = (tokens: string[], ctx: { pos: number }): number => {
+  const token = tokens[ctx.pos];
+
+  if (token === 'log') {
+    ctx.pos++;
+    const value = parsePrimary(tokens, ctx);
+    return Math.log(value);
+  }
+
+  if (token === '(') {
+    ctx.pos++;
+    const value = parseExpression(tokens, ctx);
+    if (tokens[ctx.pos] !== ')') throw new Error('Missing closing parenthesis');
+    ctx.pos++;
+    return value;
+  }
+
+  // Must be a number
+  const num = parseFloat(token);
+  if (isNaN(num)) throw new Error(`Expected number but got '${token}'`);
+  ctx.pos++;
+  return num;
+};
+
+const calculateTaxesByTypeFormel = (amount: Dinero<number>, tarif: TaxTarif) => {
+  const wert = dineroToNumber(amount);
+
+  // Find applicable bracket (same logic as BUND - last bracket where amount <= income)
+  let lastTarif: TaxTarifTableItem | undefined;
+  for (let i = 0; i < tarif.table.length; i++) {
+    const tarifItem = tarif.table[i];
+    if (tarifItem.amount <= wert) {
+      lastTarif = tarifItem;
+    } else {
+      break;
+    }
+  }
+
+  if (!lastTarif) {
+    throw new Error(
+      `No Tarif found for income ${wert}, ${tarif.taxType}, ${tarif.tableType}`
+    );
+  }
+
+  if (!lastTarif.formula || lastTarif.formula.trim() === '') {
+    return dineroChf(0);
+  }
+
+  const result = evaluateFormula(lastTarif.formula, wert);
+  if (!Number.isFinite(result)) {
+    return dineroChf(0);
+  }
+  return dineroChf(Math.max(0, result));
 };
 
 export const calculateTaxesForTarif = async (

--- a/lib/taxes/tarif/test/tarif.test.ts
+++ b/lib/taxes/tarif/test/tarif.test.ts
@@ -10,8 +10,8 @@ describe('tarif', () => {
     expect(await getTaxTarifTable(0, 2022, 'EINKOMMENSSTEUER', ['LEDIG_ALLEINE'])).toBeTruthy();
   });
 
-  test('get tarif by canton throws if not found', () => {
-    expect(
+  test('get tarif by canton throws if not found', async () => {
+    await expect(
       getTaxTarifTable(-1, 2022, 'EINKOMMENSSTEUER', ['LEDIG_ALLEINE'])
     ).rejects.toThrowError();
   });
@@ -107,6 +107,91 @@ describe('tarif', () => {
       ]
     };
     expect(dineroToNumber(calculateTaxesAmount(dineroChf(amount), tarif))).toBe(expected);
+  });
+
+  test.each<{ amount: number; expected: number }>([
+    { amount: 0, expected: 0 },
+    { amount: 5000, expected: 0 },
+    { amount: 20000, expected: 256.9 },
+    { amount: 100000, expected: 11223.8 }
+  ])('calculate taxes amount type formel', ({ amount, expected }) => {
+    const tarif: TaxTarif = {
+      group: 'LEDIG_ALLEINE',
+      taxType: 'EINKOMMENSSTEUER',
+      tableType: 'FORMEL',
+      splitting: 0,
+      table: [
+        { formula: '', taxes: 0, percent: 0, amount: 0 },
+        {
+          formula:
+            '-0.827429* $wert$ + 0.089718* $wert$ * (log $wert$ - 1) + 829.418770',
+          taxes: 0,
+          percent: 0,
+          amount: 16716
+        },
+        {
+          formula:
+            '-0.328481* $wert$ + 0.043109 * $wert$ * (log $wert$ - 1) + (-1248.266121)',
+          taxes: 0,
+          percent: 0,
+          amount: 44577
+        },
+        {
+          formula:
+            '0.051162* $wert$ + 0.010441 * $wert$ * (log $wert$ - 1) + (-4888.819148)',
+          taxes: 0,
+          percent: 0,
+          amount: 111442
+        }
+      ]
+    };
+    expect(dineroToNumber(calculateTaxesAmount(dineroChf(amount), tarif))).toBeCloseTo(
+      expected,
+      1
+    );
+  });
+
+  test('calculate taxes amount type formel clamps negative values to zero', () => {
+    const tarif: TaxTarif = {
+      group: 'LEDIG_ALLEINE',
+      taxType: 'EINKOMMENSSTEUER',
+      tableType: 'FORMEL',
+      splitting: 0,
+      table: [{ formula: '-2 * $wert$', taxes: 0, percent: 0, amount: 0 }]
+    };
+
+    expect(dineroToNumber(calculateTaxesAmount(dineroChf(1000), tarif))).toBe(0);
+  });
+
+  test.each<{ formula: string }>([
+    { formula: 'log ($wert$ - $wert$)' },
+    { formula: '0 / 0' }
+  ])('calculate taxes amount type formel returns zero for non-finite result: $formula', ({ formula }) => {
+    const tarif: TaxTarif = {
+      group: 'LEDIG_ALLEINE',
+      taxType: 'EINKOMMENSSTEUER',
+      tableType: 'FORMEL',
+      splitting: 0,
+      table: [{ formula, taxes: 0, percent: 0, amount: 0 }]
+    };
+
+    expect(dineroToNumber(calculateTaxesAmount(dineroChf(1000), tarif))).toBe(0);
+  });
+
+  test.each<{ formula: string }>([
+    { formula: '$notwert$ + 1' },
+    { formula: '1 + (2' },
+    { formula: '1 2' }
+  ])('calculate taxes amount type formel throws for invalid formula: $formula', ({ formula }) => {
+    const tarif: TaxTarif = {
+      group: 'LEDIG_ALLEINE',
+      taxType: 'EINKOMMENSSTEUER',
+      tableType: 'FORMEL',
+      splitting: 0,
+      table: [{ formula, taxes: 0, percent: 0, amount: 0 }]
+    };
+
+    expect(() => calculateTaxesAmount(dineroChf(1000), tarif)).toThrowError();
   });
 
   test.each<{ amount: number; expected: number }>([


### PR DESCRIPTION
## Summary
- Implements the previously unimplemented `FORMEL` tax table type which was returning `0` for all calculations
- Adds a safe recursive descent formula parser that evaluates logarithmic tax formulas (`$wert$`, `log`, arithmetic operators)
- Fixes incorrect tax totals for **Basel-Land (BL)** and **Bern (BE)** cantons

**Before**: Läufelfingen BL, single, 100k income → 1,633 CHF (cantonal/city income tax was 0)
**After**: Läufelfingen BL, single, 100k income → 17,834 CHF (closely matches official calculator's 16,657 CHF; remaining diff is due to deduction differences)

## Test plan
- [x] Added unit tests for FORMEL formula evaluation (bracket selection, real BL formulas, edge cases)
- [x] Added tests for negative value clamping, non-finite results (log(0), 0/0), and invalid formulas
- [x] All 108 existing tests continue to pass
- [x] Verified via API with the exact scenario from the issue (Läufelfingen BL, 2025, single, 35, 100k, 0 fortune)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)