### PR TITLE
Fix: Skip round-down-to-100 for FORMEL tarif type

### DIFF
--- a/lib/taxes/tarif/index.ts
+++ b/lib/taxes/tarif/index.ts
@@ -326,8 +326,11 @@ export const calculateTaxesForTarif = async (
     taxableIncome = multiplyDineroFactor(taxableIncome, 1 / tarifIncome.splitting, 5);
   }
 
-  const taxableIncomeRounded = dineroRound100Down(taxableIncome);
-  const taxes = calculateTaxesAmount(taxableIncomeRounded, tarifIncome);
+  // FORMEL uses continuous formulas that expect the exact taxable income;
+  // other types use discrete brackets where rounding to 100 is required.
+  const taxableIncomeForCalc =
+    tarifIncome.tableType === 'FORMEL' ? taxableIncome : dineroRound100Down(taxableIncome);
+  const taxes = calculateTaxesAmount(taxableIncomeForCalc, tarifIncome);
 
   // Apply splitting if tarif includes splitting
   if (tarifIncome.splitting > 0 && isGroupEligableForSplitting(tarifGroupUsed)) {


### PR DESCRIPTION
## Summary
- FORMEL tarif types use continuous mathematical formulas that expect the exact taxable income
- The existing `dineroRound100Down` (rounding to nearest 100) was introducing a ~10 CHF error in cantonal/city taxes for BL and BE cantons
- This skips the rounding step for FORMEL while keeping it for discrete bracket types (BUND, ZUERICH, FREIBURG, FLATTAX)

**Before** (Läufelfingen BL, single, 35, 100k gross, PK 3538):
Kantonssteuer 9'096 | Gemeindesteuer 5'840 | Total 16'641

**After**:
Kantonssteuer 9'106 | Gemeindesteuer 5'846 | Total 16'657

Now exactly matches the official calculator (https://swisstaxcalculator.estv.admin.ch).

## Test plan
- [x] All 114 tests pass
- [x] Verified exact match with official calculator for the scenario from #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)